### PR TITLE
adding state border for #74

### DIFF
--- a/layout/css/matthew-svg.css
+++ b/layout/css/matthew-svg.css
@@ -15,7 +15,11 @@ line, polyline, path{
 .river-polyline {
 	stroke: #1E90FF;
 }
-		
+.state-border	{
+  fill:none;
+  stroke: #2F4F4F;
+  stroke-width:2;
+}
 .track-polyline {
   stroke: #e0eeee;
   stroke-width:2;

--- a/scripts/visualize/visualize.matthew_map.R
+++ b/scripts/visualize/visualize.matthew_map.R
@@ -14,7 +14,7 @@ visualize.matthew_map <- function(viz){
   legend.bins <- readData(viz[['depends']][8])
   legend.breaks <- readData(viz[['depends']][9])
   spark.sites <- readData(viz[['depends']][10])
-  
+  state.borders <- readData(viz[['depends']][11])
   library(svglite)
   library(dplyr)
   
@@ -22,6 +22,7 @@ visualize.matthew_map <- function(viz){
   par(mai=c(0,0,0,0), omi=c(0,0,0,0))
   sp::plot(counties)
   sp::plot(flowlines, add=TRUE)
+  sp::plot(state.borders, add=TRUE)
   sp::plot(states, add=TRUE)
   sp::plot(track, add=TRUE)
   sp::plot(gages, pch=20, add=TRUE)
@@ -68,9 +69,13 @@ visualize.matthew_map <- function(viz){
 
   }
   
-  for (j in (i+1):length(p)){
-    xml_attr(p[[j]], 'class') <- 'state-polygon'
+  for (j in (i+1):(i+length(state.borders))){
+    xml_attr(p[[j]], 'class') <- 'state-border'
     xml_attr(p[[j]], 'clip-path') <- "url(#svg-bounds)"
+  }
+  for (i in (j+1):length(p)){
+    xml_attr(p[[i]], 'class') <- 'state-polygon'
+    xml_attr(p[[i]], 'clip-path') <- "url(#svg-bounds)"
   }
 
   g.rivers <- xml_add_child(svg, 'g', id='rivers','class'='river-polyline')

--- a/viz.yaml
+++ b/viz.yaml
@@ -180,7 +180,7 @@ visualize:
     location: figures/matthew-water.svg
     visualizer: matthew_map
     depends: ["matthew-counties","matthew-flowlines", "matthew-states", "storm-track", "classifyBins", 
-      'storm-location',"matthew-sites", "precip-colors", "precip-breaks", "discharge-sparks"]
+      'storm-location',"matthew-sites", "precip-colors", "precip-breaks", "discharge-sparks","matthew-borders"]
     scripts: scripts/visualize/visualize.matthew_map.R
     mapdata: "matthew-counties"
     mimetype: image/svg+xml


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2349007/19256234/a166c0b8-8f2a-11e6-8bb0-8fb52721c914.png)

Added state borders. For a full fix, we'd want to move these elements to later in the svg so they sit on top of the other states and counties (so they aren't partially covered)...but...

@ldecicco-USGS they way we have to do this w/ the current svg building w/ maps is count elements that we know are of certain types, and then move them around or change their attributes (or remove them). Since I know all the counties are within the viewbox and will be plotted and able to be counted, I start with those. Then I plot the five states we want the borders from and I know all of those will be plotted and counted. Then I move on to the other states, which I don't really know how many will exist (because of the cropping). That is why the regular state poly types count to `length(p)` instead of some known number of states. (`p` is all of the `path` elements of the svg). The hacky thing here is knowing what all of the plots that we add will come in as. The dots are going to be `circle` elements, the polygons are going to be `path` elements, and the polylines are going to by `polyline` elements, etc. I created dinosvg to avoid this type of climbing the dom and assuming counts. But it doesn't do maps right now. 
